### PR TITLE
Improve POS weight pricing behavior

### DIFF
--- a/addons_custom/product_weight_pricing/__manifest__.py
+++ b/addons_custom/product_weight_pricing/__manifest__.py
@@ -11,6 +11,7 @@
     ],
     "assets": {
         "point_of_sale.assets": [
+            "addons_custom/product_weight_pricing/static/src/js/pos_pricing_method.js",
             "addons_custom/product_weight_pricing/static/src/xml/pos_weight_orderline.xml",
         ],
     },

--- a/addons_custom/product_weight_pricing/models/__init__.py
+++ b/addons_custom/product_weight_pricing/models/__init__.py
@@ -1,2 +1,3 @@
 from . import product_template
+from . import product_product
 

--- a/addons_custom/product_weight_pricing/models/product_product.py
+++ b/addons_custom/product_weight_pricing/models/product_product.py
@@ -1,0 +1,45 @@
+from odoo import api, models
+from odoo.tools.float_utils import float_round
+
+
+class ProductProduct(models.Model):
+    _inherit = "product.product"
+
+    @api.model
+    def _load_pos_data_fields(self, config_id):
+        fields = super()._load_pos_data_fields(config_id)
+        if "weight" not in fields:
+            fields.append("weight")
+        return fields
+
+    def pos_compute_price_by_weight(self, company_id=False):
+        self.ensure_one()
+        template = self.product_tmpl_id
+        if template.pos_pricing_method != "by_weight":
+            return {}
+
+        company = (
+            self.env["res.company"].browse(company_id)
+            if company_id
+            else self.env.company
+        )
+        if not company:
+            company = self.env.company
+
+        weight_kg = self.weight or template.weight or 0.0
+        weight_g = float_round(weight_kg * 1000.0, precision_digits=3)
+
+        metal_type = template.default_metal_type or "au_9999"
+        price_per_g, factor = self.env["metal.pricelist"].sudo().get_price(
+            company.id, metal_type
+        )
+        factor = factor or 1.0
+        unit_price = float_round(price_per_g * factor, precision_digits=2)
+
+        return {
+            "weight_g": weight_g,
+            "unit_price": unit_price,
+            "price_per_g": price_per_g,
+            "fineness_factor": factor,
+        }
+

--- a/addons_custom/product_weight_pricing/models/product_template.py
+++ b/addons_custom/product_weight_pricing/models/product_template.py
@@ -31,6 +31,15 @@ class ProductTemplate(models.Model):
         for rec in self:
             rec.weight = (rec.weight_g or 0.0) / 1000.0
 
+    @api.model
+    def _load_pos_data_fields(self, config_id):
+        fields = super()._load_pos_data_fields(config_id)
+        extra_fields = ["pos_pricing_method", "default_metal_type", "weight"]
+        for field_name in extra_fields:
+            if field_name not in fields:
+                fields.append(field_name)
+        return fields
+
     @api.onchange("pos_pricing_method")
     def _onchange_pos_pricing_method_set_uom(self):
         """Force Unit of Measure based on pricing method.

--- a/addons_custom/product_weight_pricing/static/src/js/pos_pricing_method.js
+++ b/addons_custom/product_weight_pricing/static/src/js/pos_pricing_method.js
@@ -1,0 +1,62 @@
+/** @odoo-module **/
+
+import { patch } from "@web/core/utils/patch";
+import { PosStore } from "@point_of_sale/app/store/pos_store";
+
+const _superAddLineToOrder = PosStore.prototype.addLineToOrder;
+
+patch(PosStore.prototype, {
+    async addLineToOrder(vals, order, opts = {}, configure = true) {
+        let productRecord = vals.product_id;
+        if (typeof productRecord === "number") {
+            productRecord = this.data.models["product.product"].get(productRecord);
+        }
+
+        const pricingMethod = productRecord
+            ? productRecord.pos_pricing_method ??
+              productRecord.product_tmpl_id?.pos_pricing_method ??
+              productRecord.raw?.pos_pricing_method
+            : undefined;
+
+        if (
+            productRecord &&
+            (vals.price_unit === undefined || vals.price_unit === null) &&
+            pricingMethod === "by_weight"
+        ) {
+            try {
+                const companyId = this.company?.id || false;
+                const priceData = await this.data.call(
+                    "product.product",
+                    "pos_compute_price_by_weight",
+                    [[productRecord.id], companyId]
+                );
+
+                if (priceData) {
+                    const weightQty = Number(priceData.weight_g);
+                    const unitPrice = Number(priceData.unit_price);
+
+                    if (
+                        !Number.isNaN(weightQty) &&
+                        weightQty > 0 &&
+                        (vals.qty === undefined || vals.qty === 1)
+                    ) {
+                        vals.qty = weightQty;
+                    }
+
+                    if (!Number.isNaN(unitPrice) && unitPrice > 0) {
+                        vals.price_unit = unitPrice;
+                        vals.price_type = "manual";
+                    }
+                }
+            } catch (error) {
+                console.warn(
+                    "product_weight_pricing: failed to compute weight-based price",
+                    error
+                );
+            }
+        }
+
+        return await _superAddLineToOrder.call(this, vals, order, opts, configure);
+    },
+});
+


### PR DESCRIPTION
## Summary
- expose product weight and pricing metadata to the POS loader
- add a POS RPC helper to compute weight-based prices from the metal pricelist
- override the POS order flow to apply weight quantities and gold pricing when adding products

## Testing
- python -m compileall addons_custom/product_weight_pricing

------
https://chatgpt.com/codex/tasks/task_e_68e60f770ea08320885022e9637f8b55