### PR TITLE
[FIX] product_weight_pricing: show weight pricing summary

### DIFF
--- a/addons_custom/product_weight_pricing/static/src/js/pos_pricing_method.js
+++ b/addons_custom/product_weight_pricing/static/src/js/pos_pricing_method.js
@@ -1,9 +1,12 @@
 /** @odoo-module **/
 
 import { patch } from "@web/core/utils/patch";
+import { formatFloat } from "@web/core/utils/numbers";
+import { PosOrderline } from "@point_of_sale/app/models/pos_order_line";
 import { PosStore } from "@point_of_sale/app/store/pos_store";
 
 const _superAddLineToOrder = PosStore.prototype.addLineToOrder;
+const _superGetDisplayData = PosOrderline.prototype.getDisplayData;
 
 patch(PosStore.prototype, {
     async addLineToOrder(vals, order, opts = {}, configure = true) {
@@ -34,6 +37,12 @@ patch(PosStore.prototype, {
                 if (priceData) {
                     const weightQty = Number(priceData.weight_g);
                     const unitPrice = Number(priceData.unit_price);
+                    const weightInfo = {
+                        weight_g: Number.isFinite(weightQty) ? weightQty : 0,
+                        unit_price: Number.isFinite(unitPrice) ? unitPrice : 0,
+                        price_per_g: Number(priceData.price_per_g || 0),
+                        fineness_factor: Number(priceData.fineness_factor || priceData.factor || 1),
+                    };
 
                     if (
                         !Number.isNaN(weightQty) &&
@@ -47,6 +56,9 @@ patch(PosStore.prototype, {
                         vals.price_unit = unitPrice;
                         vals.price_type = "manual";
                     }
+
+                    // Preserve the raw data for UI display (Base.setup keeps fields prefixed with _)
+                    vals._weight_pricing = weightInfo;
                 }
             } catch (error) {
                 console.warn(
@@ -57,6 +69,42 @@ patch(PosStore.prototype, {
         }
 
         return await _superAddLineToOrder.call(this, vals, order, opts, configure);
+    },
+});
+
+patch(PosOrderline.prototype, {
+    /**
+     * True when the linked product should display the By Weight label.
+     */
+    isWeightPriced() {
+        const product = this.product_id;
+        const tmplMethod = product?.product_tmpl_id?.pos_pricing_method || product?.raw?.pos_pricing_method;
+        return (product?.pos_pricing_method || tmplMethod) === "by_weight";
+    },
+
+    /**
+     * Returns the formatted quantity (in grams) for By Weight products.
+     */
+    _getWeightQtyDisplay() {
+        const weightData = this._weight_pricing;
+        const qtySource =
+            weightData?.weight_g ?? this.qty ?? 0;
+        const decimals = this.models["decimal.precision"].find((dp) => dp.name === "Product Unit of Measure")?.digits || 2;
+        return formatFloat(qtySource, { digits: [69, decimals] });
+    },
+
+    getDisplayData() {
+        const data = _superGetDisplayData.apply(this, arguments);
+
+        if (this.isWeightPriced() && data.unit === "g") {
+            const qtyStr = this._getWeightQtyDisplay();
+            const unitPrice = data.unitPrice || "";
+            if (qtyStr && unitPrice) {
+                data.weightPricingLabel = `${unitPrice}/${data.unit} x ${qtyStr}${data.unit}`;
+            }
+        }
+
+        return data;
     },
 });
 

--- a/addons_custom/product_weight_pricing/static/src/xml/pos_weight_orderline.xml
+++ b/addons_custom/product_weight_pricing/static/src/xml/pos_weight_orderline.xml
@@ -1,21 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
   <!--
-    Make By Weight lines display as: "Weight: <qty> g" in a single line.
+    Make By Weight lines display the formatted label "<price>/g x <qty>g".
     Heuristic: detect gram UoM via line.unit === 'g' (matches standard UoM name).
-    Falls back to the original layout for other units.
+    Falls back to the original layout for other units or missing data.
   -->
   <t t-name="product_weight_pricing.OrderlineByWeight"
      t-inherit="point_of_sale.Orderline"
      t-inherit-mode="extension">
     <xpath expr="//li[contains(concat(' ', normalize-space(@class), ' '), ' price-per-unit ')]" position="replace">
       <li class="price-per-unit">
-        <!-- When unit is grams, render one-line Weight display, no "per g" -->
-        <t t-if="line.unit === 'g'">
-          <span class="fw-bolder">Weight: </span>
-          <t t-esc="line.qty"/> g
+        <!-- When unit is grams, render computed label (unit price × weight) -->
+        <t t-if="line.weightPricingLabel">
+          <span class="fw-bolder" t-esc="line.weightPricingLabel"/>
         </t>
-        <!-- Default rendering for non-gram units: copy of core template -->
+        <!-- Default rendering for non-gram units or missing pricing info -->
         <t t-else="">
           <span class="qty px-1 border rounded text-bg-view fw-bolder me-1" t-esc="line.qty"/>
           <t t-if="!props.basic_receipt">


### PR DESCRIPTION
## Summary
- keep the RPC result from `pos_compute_price_by_weight` on the order line so we can format the display
- format by-weight POS order lines as `<price>/g x <qty>g` instead of showing a zero quantity

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e62bc68d9483208871a4d349ea8295