### PR TITLE
Allow configuring POS metal types

### DIFF
--- a/addons_custom/pos_gold_pricing/README.md
+++ b/addons_custom/pos_gold_pricing/README.md
@@ -5,20 +5,21 @@
 
 ## 功能
 - 在 `stock.production.lot` 上扩展首饰字段：净金重、证书号、工费等
-- 新模型 `metal.pricelist` 维护每日金价/成色系数
+- 新模型 `pos.metal.type` 维护可配置金种，`metal.pricelist` 维护每日金价/成色系数
 - POS 前端：选择序列号后经 RPC 调用服务器计算单价并写入行价
 
 ## 安装
 1. 将本目录放入 Odoo 的 `--addons-path` 路径下（或直接安装 ZIP）。
 2. 更新应用列表，安装 **POS Gold Pricing** 模块。
-3. 在菜单 **Point of Sale / Metal Pricing / Daily Metal Prices** 里维护当日金价。
-4. 在产品模板上：勾选 *Available in POS*，`tracking=serial`，设置 POS 分类。
-5. 在 POS 配置中启用 *Lots/Serials*，重开会话。
+3. 在菜单 **Point of Sale / Metal Pricing / Metal Types** 里维护业务所需的金种（名称/编码，可按公司划分）。
+4. 在菜单 **Point of Sale / Metal Pricing / Daily Metal Prices** 中为各金种维护当日金价与成色系数。
+5. 在产品模板上：勾选 *Available in POS*，`tracking=serial`，设置 POS 分类，并选择默认金种（可选）。
+6. 在 POS 配置中启用 *Lots/Serials*，重开会话。
 
 ## 批量导入模板（CSV 在 `samples/` 目录）
 - `pos_categories.csv` ：POS 分类（大类/子类）
 - `products.csv` ：产品模板（可售、serial 跟踪、POS 分类）
-- `lots.csv` ：序列号（净金重、工费、证书等单件差异）
+- `lots.csv` ：序列号（净金重、工费、证书等单件差异；导入前请先创建好金种并映射 `metal_type_id/id`）
 
 导入：进入对应模型列表，点击“导入”，映射列，测试后导入。导入后重开 POS 会话。
 

--- a/addons_custom/pos_gold_pricing/__manifest__.py
+++ b/addons_custom/pos_gold_pricing/__manifest__.py
@@ -1,7 +1,7 @@
 
 {
     "name": "POS Gold Pricing",
-    "version": "18.0.1.0",
+    "version": "18.0.2.0",
     "summary": "POS 动态计价（黄金/首饰：净金重×当日金价+工费）",
     "category": "Point of Sale",
     "website": "https://example.com",
@@ -10,6 +10,7 @@
     "depends": ["point_of_sale", "stock"],
     "data": [
         "security/ir.model.access.csv",
+        "views/metal_type_views.xml",
         "views/metal_pricelist_views.xml",
         "views/stock_production_lot_views.xml",
         "views/product_template_views.xml",

--- a/addons_custom/pos_gold_pricing/models/__init__.py
+++ b/addons_custom/pos_gold_pricing/models/__init__.py
@@ -1,4 +1,5 @@
 
+from . import metal_type
 from . import metal_pricelist
 from . import stock_lot
 from . import product_template

--- a/addons_custom/pos_gold_pricing/models/metal_pricelist.py
+++ b/addons_custom/pos_gold_pricing/models/metal_pricelist.py
@@ -6,12 +6,13 @@ class MetalPricelist(models.Model):
     _description = "Metal daily price for jewelry"
 
     name = fields.Char("Name", required=True)
-    metal_type = fields.Selection([
-        ('au_9999', 'Au 999.9'),
-        ('au_999',  'Au 999'),
-        ('au_au18k','Au 18K'),
-        ('au_au14k','Au 14K'),
-    ], required=True, help="金种/成色")
+    metal_type_id = fields.Many2one(
+        "pos.metal.type",
+        string="Metal Type",
+        required=True,
+        ondelete="restrict",
+        help="Metal type this daily price applies to.",
+    )
     price_per_g = fields.Float("Price (CNY/gram)", digits=(16, 4), required=True)
     fineness_factor = fields.Float("Fineness Factor", default=1.0, help="成色系数，如 18K ~ 0.75")
     effective_date = fields.Date("Effective Date", required=True)
@@ -19,17 +20,23 @@ class MetalPricelist(models.Model):
     active = fields.Boolean(default=True)
 
     _sql_constraints = [
-        ('uniq_day_metal_company', 'unique(metal_type, effective_date, company_id)',
-         '同一天、同一金种、同一公司只能有一条当日金价。')
+        (
+            'uniq_day_metal_company',
+            'unique(metal_type_id, effective_date, company_id)',
+            '同一天、同一金种、同一公司只能有一条当日金价。',
+        )
     ]
 
     @api.model
-    def get_price(self, company_id, metal_type, on_date=None):
+    def get_price(self, company_id, metal_type_id, on_date=None):
         """Return (price_per_g, fineness_factor) for the given day/metal/company."""
+        if not metal_type_id:
+            return 0.0, 1.0
+
         on_date = on_date or fields.Date.context_today(self)
         rec = self.search([
             ('company_id', '=', company_id),
-            ('metal_type', '=', metal_type),
+            ('metal_type_id', '=', metal_type_id),
             ('effective_date', '<=', on_date),
             ('active', '=', True),
         ], order="effective_date desc", limit=1)

--- a/addons_custom/pos_gold_pricing/models/metal_type.py
+++ b/addons_custom/pos_gold_pricing/models/metal_type.py
@@ -1,0 +1,28 @@
+from odoo import fields, models
+
+
+class PosMetalType(models.Model):
+    """Configurable metal types used by POS gold pricing."""
+
+    _name = "pos.metal.type"
+    _description = "POS Metal Type"
+    _order = "sequence, name"
+
+    name = fields.Char(required=True, translate=True)
+    code = fields.Char(required=True)
+    sequence = fields.Integer(default=10)
+    company_id = fields.Many2one(
+        "res.company",
+        string="Company",
+        default=lambda self: self.env.company,
+        help="Restrict the metal type to a specific company if needed.",
+    )
+    active = fields.Boolean(default=True)
+
+    _sql_constraints = [
+        (
+            "pos_metal_type_unique_code_company",
+            "unique(code, company_id)",
+            "The metal type code must be unique per company.",
+        )
+    ]

--- a/addons_custom/pos_gold_pricing/models/product_template.py
+++ b/addons_custom/pos_gold_pricing/models/product_template.py
@@ -4,7 +4,9 @@ from odoo import models, fields
 class ProductTemplate(models.Model):
     _inherit = "product.template"
 
-    default_metal_type = fields.Selection([
-        ('au_9999','Au 999.9'), ('au_999','Au 999'), ('au_au18k','Au 18K'), ('au_au14k','Au 14K')
-    ], string="默认金种")
+    default_metal_type_id = fields.Many2one(
+        "pos.metal.type",
+        string="默认金种",
+        help="选择默认的金种，以便在 POS 中自动选取当日金价。",
+    )
     default_wage_type = fields.Selection([('per_g','克工费'), ('per_piece','件工费')], default='per_piece')

--- a/addons_custom/pos_gold_pricing/models/stock_lot.py
+++ b/addons_custom/pos_gold_pricing/models/stock_lot.py
@@ -18,19 +18,19 @@ class StockProductionLot(models.Model):
         ("5g", "5G"),
         ("enamel", "珐琅"),
     ], string="工艺")
-    metal_type = fields.Selection([
-        ("au_9999", "Au 999.9"),
-        ("au_999", "Au 999"),
-        ("au_au18k", "Au 18K"),
-        ("au_au14k", "Au 14K"),
-    ], string="金种/成色", help="用于匹配当日金价；也可从模板继承默认值。")
+    metal_type_id = fields.Many2one(
+        "pos.metal.type",
+        string="金种/成色",
+        help="用于匹配当日金价；也可从模板继承默认值。",
+    )
 
     def compute_pos_unit_price(self):
         """服务器侧统一算价：净金重×当日金价×成色系数 + 工费"""
         self.ensure_one()
         company_id = self.company_id.id or self.env.company.id
+        metal_type = self.metal_type_id or self.product_id.product_tmpl_id.default_metal_type_id
         price_per_g, factor = self.env["metal.pricelist"].get_price(
-            company_id, self.metal_type or "au_9999"
+            company_id, metal_type.id if metal_type else False
         )
         gold_part = (self.net_gold_weight or 0.0) * price_per_g * (factor or 1.0)
         if self.wage_type == "per_g":

--- a/addons_custom/pos_gold_pricing/samples/lots.csv
+++ b/addons_custom/pos_gold_pricing/samples/lots.csv
@@ -1,5 +1,5 @@
 
-name,product_id/id,company_id/id,metal_type,net_gold_weight,gross_weight,stone_weight_ct,wage_type,wage_value,process_technique,certificate_no
-SN-GR-A-0001,pt_gold_ring_001,base.main_company,au_9999,3.56,3.70,0.10,per_piece,120.00,hard,CERT-0001
-SN-GR-A-0002,pt_gold_ring_001,base.main_company,au_9999,3.48,3.60,0.00,per_g,10.00,3d,CERT-0002
-SN-GB-A-0001,pt_gold_bangle_001,base.main_company,au_9999,15.23,15.50,0.00,per_piece,280.00,5d,CERT-1001
+name,product_id/id,company_id/id,metal_type_id/id,net_gold_weight,gross_weight,stone_weight_ct,wage_type,wage_value,process_technique,certificate_no
+SN-GR-A-0001,pt_gold_ring_001,base.main_company,,3.56,3.70,0.10,per_piece,120.00,hard,CERT-0001
+SN-GR-A-0002,pt_gold_ring_001,base.main_company,,3.48,3.60,0.00,per_g,10.00,3d,CERT-0002
+SN-GB-A-0001,pt_gold_bangle_001,base.main_company,,15.23,15.50,0.00,per_piece,280.00,5d,CERT-1001

--- a/addons_custom/pos_gold_pricing/security/ir.model.access.csv
+++ b/addons_custom/pos_gold_pricing/security/ir.model.access.csv
@@ -1,2 +1,3 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_metal_pricelist_user,access_metal_pricelist_user,model_metal_pricelist,base.group_user,1,1,1,0
+access_pos_metal_type_user,access_pos_metal_type_user,model_pos_metal_type,base.group_user,1,1,1,0

--- a/addons_custom/pos_gold_pricing/views/metal_pricelist_views.xml
+++ b/addons_custom/pos_gold_pricing/views/metal_pricelist_views.xml
@@ -7,7 +7,7 @@
       <list>
         <field name="name"/>
         <field name="company_id"/>
-        <field name="metal_type"/>
+        <field name="metal_type_id" context="{'default_company_id': company_id}"/>
         <field name="price_per_g"/>
         <field name="fineness_factor"/>
         <field name="effective_date"/>
@@ -25,7 +25,7 @@
           <group>
             <field name="name"/>
             <field name="company_id"/>
-            <field name="metal_type"/>
+            <field name="metal_type_id" context="{'default_company_id': company_id}" options="{'no_create_edit': False}"/>
             <field name="price_per_g"/>
             <field name="fineness_factor"/>
             <field name="effective_date"/>

--- a/addons_custom/pos_gold_pricing/views/metal_type_views.xml
+++ b/addons_custom/pos_gold_pricing/views/metal_type_views.xml
@@ -1,0 +1,41 @@
+<odoo>
+  <record id="view_pos_metal_type_tree" model="ir.ui.view">
+    <field name="name">pos.metal.type.tree</field>
+    <field name="model">pos.metal.type</field>
+    <field name="arch" type="xml">
+      <list>
+        <field name="name"/>
+        <field name="code"/>
+        <field name="company_id"/>
+        <field name="sequence"/>
+        <field name="active"/>
+      </list>
+    </field>
+  </record>
+
+  <record id="view_pos_metal_type_form" model="ir.ui.view">
+    <field name="name">pos.metal.type.form</field>
+    <field name="model">pos.metal.type</field>
+    <field name="arch" type="xml">
+      <form string="Metal Type">
+        <sheet>
+          <group>
+            <field name="name"/>
+            <field name="code"/>
+            <field name="company_id"/>
+            <field name="sequence"/>
+            <field name="active"/>
+          </group>
+        </sheet>
+      </form>
+    </field>
+  </record>
+
+  <record id="action_pos_metal_type" model="ir.actions.act_window">
+    <field name="name">Metal Types</field>
+    <field name="res_model">pos.metal.type</field>
+    <field name="view_mode">list,form</field>
+  </record>
+
+  <menuitem id="menu_pos_metal_type" name="Metal Types" parent="menu_metal_root" action="action_pos_metal_type" sequence="5"/>
+</odoo>

--- a/addons_custom/pos_gold_pricing/views/stock_production_lot_views.xml
+++ b/addons_custom/pos_gold_pricing/views/stock_production_lot_views.xml
@@ -11,7 +11,7 @@
       <xpath expr="//sheet/notebook" position="inside">
         <page string="Jewelry">
           <group>
-            <field name="metal_type"/>
+            <field name="metal_type_id" context="{'default_company_id': company_id}" options="{'no_create_edit': False}"/>
             <field name="net_gold_weight"/>
             <field name="gross_weight"/>
             <field name="stone_weight_ct"/>

--- a/addons_custom/product_weight_pricing/__manifest__.py
+++ b/addons_custom/product_weight_pricing/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "Product Weight & Pricing Method",
-    "version": "18.0.1.4",
+    "version": "18.0.1.5",
     "summary": "Expose Weight, UoM, and a Pricing Method for gold products",
     "category": "Product",
     "author": "Your Team",

--- a/addons_custom/product_weight_pricing/models/product_product.py
+++ b/addons_custom/product_weight_pricing/models/product_product.py
@@ -29,9 +29,9 @@ class ProductProduct(models.Model):
         weight_kg = self.weight or template.weight or 0.0
         weight_g = float_round(weight_kg * 1000.0, precision_digits=3)
 
-        metal_type = template.default_metal_type or "au_9999"
+        metal_type = template.default_metal_type_id
         price_per_g, factor = self.env["metal.pricelist"].sudo().get_price(
-            company.id, metal_type
+            company.id, metal_type.id if metal_type else False
         )
         factor = factor or 1.0
         unit_price = float_round(price_per_g * factor, precision_digits=2)

--- a/addons_custom/product_weight_pricing/models/product_template.py
+++ b/addons_custom/product_weight_pricing/models/product_template.py
@@ -34,7 +34,7 @@ class ProductTemplate(models.Model):
     @api.model
     def _load_pos_data_fields(self, config_id):
         fields = super()._load_pos_data_fields(config_id)
-        extra_fields = ["pos_pricing_method", "default_metal_type", "weight"]
+        extra_fields = ["pos_pricing_method", "default_metal_type_id", "weight"]
         for field_name in extra_fields:
             if field_name not in fields:
                 fields.append(field_name)

--- a/addons_custom/product_weight_pricing/views/product_template_views.xml
+++ b/addons_custom/product_weight_pricing/views/product_template_views.xml
@@ -29,6 +29,12 @@
         </div>
       </xpath>
 
+      <xpath expr="//sheet//group//div[@name='list_price_uom'][1]" position="after">
+        <field name="default_metal_type_id"
+               attrs="{'invisible': [('pos_pricing_method', '!=', 'by_weight')]}"
+               options="{'no_create_edit': False}"/>
+      </xpath>
+
       <!-- Hide pricing-related rows when By Weight to ensure only two lines appear in this area -->
       <xpath expr="//sheet//group//field[@name='taxes_id']" position="attributes">
         <attribute name="invisible">pos_pricing_method == 'by_weight'</attribute>


### PR DESCRIPTION
## Summary
- add a configurable `pos.metal.type` model and management menu for POS gold pricing
- update daily prices, lot pricing, and products to reference the configurable metal types
- load the new metal type reference to the POS data loader for weight-based pricing

## Testing
- python3 -m compileall addons_custom/pos_gold_pricing addons_custom/product_weight_pricing

------
https://chatgpt.com/codex/tasks/task_e_68e732d0407883208e9d8382ae99b40a