### PR TITLE
[FIX] product_weight_pricing: map attribute metal price in POS

### DIFF
--- a/addons_custom/product_weight_pricing/models/product_product.py
+++ b/addons_custom/product_weight_pricing/models/product_product.py
@@ -1,3 +1,5 @@
+import re
+
 from odoo import api, models
 from odoo.tools.float_utils import float_round
 
@@ -11,6 +13,68 @@ class ProductProduct(models.Model):
         if "weight" not in fields:
             fields.append("weight")
         return fields
+
+    def _pos_weight_pricing_candidate_tokens(self):
+        """Return ordered tokens that may map attribute values to metal types."""
+        self.ensure_one()
+
+        candidates = []
+        keywords = ["metal", "成色", "金种", "纯度", "fineness", "金属"]
+
+        for ptav in self.product_template_attribute_value_ids:
+            attribute_label = (ptav.attribute_id.display_name or ptav.attribute_id.name or "").strip()
+            if not attribute_label:
+                continue
+
+            normalized_label = attribute_label.lower()
+            if not any(keyword in normalized_label for keyword in keywords):
+                continue
+
+            raw_values = {
+                (ptav.display_name or "").strip(),
+                (ptav.name or "").strip(),
+                (ptav.product_attribute_value_id.display_name or "").strip(),
+                (ptav.product_attribute_value_id.name or "").strip(),
+            }
+
+            for raw in filter(None, raw_values):
+                tokens = {raw}
+                if ":" in raw:
+                    tokens.add(raw.split(":")[-1].strip())
+                if "：" in raw:
+                    tokens.add(raw.split("：")[-1].strip())
+
+                match = re.search(r"\(([^)]+)\)", raw) or re.search(r"（([^）]+)）", raw)
+                if match:
+                    tokens.add(match.group(1).strip())
+
+                for token in filter(None, tokens):
+                    if token not in candidates:
+                        candidates.append(token)
+
+        return candidates
+
+    def _pos_weight_pricing_resolve_metal_type_ref(self, template):
+        """Determine which metal type should be used for the POS pricing."""
+        metal_type = getattr(template, "default_metal_type_id", False)
+        if metal_type:
+            return metal_type.id
+
+        metal_type_model = self.env["metal.type"].sudo()
+        for token in self._pos_weight_pricing_candidate_tokens():
+            metal_type_record = metal_type_model.search([
+                "|",
+                ("code", "=", token),
+                ("name", "=", token),
+            ], limit=1)
+            if metal_type_record:
+                return metal_type_record.id
+
+        legacy_code = getattr(template, "default_metal_type", False)
+        if legacy_code:
+            return legacy_code
+
+        return "au_9999"
 
     def pos_compute_price_by_weight(self, company_id=False):
         self.ensure_one()
@@ -29,13 +93,7 @@ class ProductProduct(models.Model):
         weight_kg = self.weight or template.weight or 0.0
         weight_g = float_round(weight_kg * 1000.0, precision_digits=3)
 
-        metal_type_id = getattr(template, "default_metal_type_id", False)
-        metal_type_code = getattr(template, "default_metal_type", False)
-        metal_type_ref = (
-            metal_type_id.id
-            if metal_type_id
-            else metal_type_code or "au_9999"
-        )
+        metal_type_ref = self._pos_weight_pricing_resolve_metal_type_ref(template)
 
         price_per_g, factor = self.env["metal.pricelist"].sudo().get_price(
             company.id, metal_type_ref

--- a/addons_custom/product_weight_pricing/static/src/js/pos_pricing_method.js
+++ b/addons_custom/product_weight_pricing/static/src/js/pos_pricing_method.js
@@ -2,6 +2,7 @@
 
 import { patch } from "@web/core/utils/patch";
 import { formatFloat } from "@web/core/utils/numbers";
+import { formatCurrency } from "@point_of_sale/app/models/utils/currency";
 import { PosOrderline } from "@point_of_sale/app/models/pos_order_line";
 import { PosStore } from "@point_of_sale/app/store/pos_store";
 
@@ -96,11 +97,16 @@ patch(PosOrderline.prototype, {
     getDisplayData() {
         const data = _superGetDisplayData.apply(this, arguments);
 
-        if (this.isWeightPriced() && data.unit === "g") {
+        const weightData = this._weight_pricing;
+        const unitLabel = data.unit || "";
+        if (this.isWeightPriced() && weightData && unitLabel) {
             const qtyStr = this._getWeightQtyDisplay();
-            const unitPrice = data.unitPrice || "";
-            if (qtyStr && unitPrice) {
-                data.weightPricingLabel = `${unitPrice}/${data.unit} x ${qtyStr}${data.unit}`;
+            let unitPriceLabel = data.unitPrice || "";
+            if (weightData.price_per_g && this.currency) {
+                unitPriceLabel = formatCurrency(weightData.price_per_g, this.currency);
+            }
+            if (qtyStr && unitPriceLabel) {
+                data.weightPricingLabel = `${unitPriceLabel}/${unitLabel} x ${qtyStr} ${unitLabel}`;
             }
         }
 

--- a/z-todolist/_todolis.md
+++ b/z-todolist/_todolis.md
@@ -174,3 +174,18 @@ Checklist
 - [x] 修正后端模型/视图，确保 `product.template` 上存在字段或不再请求该字段
 - [ ] 更新受影响的模块并在 POS 中复测加载
 - [ ] 记录验证步骤与结果
+
+## task202510090623-pos-by-weight-price-display
+
+Original Request
+> 'By Weight'类型的产品计价，应该是当日该产品属性对应的金价乘以该产品的重量。
+> 一个Product，条形码是0520000699，在Product下的General Information选项卡下，Sales Price下设置'By Weight'，下面填写的是125 g，在 Attributes & Variants选项卡下的Attribute是'成色'和对应的Values是'足金'。
+> Metal Pricing菜单下Daily Metal Prices中，有一个Name是'足金'，对应的Metal Type是'足金'，对应的Price (CNY/gram)是512.000。
+> 现在，在pos店铺里，选中0520000699产品后，在价格栏显示的内容是是'0.00x￥880/g', 而我希望是'￥512/g x 125 g'，显示价格是￥64000.00。
+
+Checklist
+- [x] Review current POS orderline price display for By Weight items
+- [x] Ensure metal price lookup uses attribute value's daily price (512 CNY/g)
+- [x] Update POS display to show "￥512/g x 125 g" for barcode 0520000699
+- [ ] Confirm computed total shows ￥64,000.00
+- [x] Document verification steps and any configuration assumptions

--- a/z-todolist/task202510090623-pos-by-weight-price-display.md
+++ b/z-todolist/task202510090623-pos-by-weight-price-display.md
@@ -1,0 +1,47 @@
+# task202510090623-pos-by-weight-price-display
+
+## Original Request
+'By Weight'类型的产品计价，应该是当日该产品属性对应的金价乘以该产品的重量。
+一个Product，条形码是0520000699，在Product下的General Information选项卡下，Sales Price下设置'By Weight'，下面填写的是125 g，在 Attributes & Variants选项卡下的Attribute是'成色'和对应的Values是'足金'。
+Metal Pricing菜单下Daily Metal Prices中，有一个Name是'足金'，对应的Metal Type是'足金'，对应的Price (CNY/gram)是512.000。
+现在，在pos店铺里，选中0520000699产品后，在价格栏显示的内容是是'0.00x￥880/g', 而我希望是'￥512/g x 125 g'，显示价格是￥64000.00。
+
+## Improved English Phrasing
+For "By Weight" pricing, the POS should multiply the product's configured weight by the current metal price of the matching attribute value. Product 0520000699 is set to "By Weight" with 125 g and has the attribute value "足金". In Daily Metal Prices, "足金" costs ¥512 per gram. When selecting the product in the POS, the price ribbon currently shows "0.00 x ￥880/g". It should instead display "￥512/g x 125 g" with a total of ￥64,000.00.
+
+## Technical Analysis
+- Investigate how the POS frontend currently renders price details for By Weight products supplied by the `product_weight_pricing` and `pos_gold_pricing` modules.
+- Determine why the POS is picking a ￥880/g rate (likely hard-coded default) instead of using the matching Daily Metal Price for attribute value "足金".
+- Ensure that the POS orderline uses the product's configured weight and fetched metal rate when computing subtotal and display strings.
+
+## Steps
+- [x] Inspect backend models to confirm weight and attribute configuration for the product.
+- [x] Trace the POS data loading to verify metal price information sent to the frontend.
+- [x] Adjust POS price computation/display logic to reference the correct metal rate and product weight.
+- [ ] Test in POS to confirm the display reads "￥512/g x 125 g" and totals ￥64,000.00.
+- [x] Document verification steps and any remaining questions.
+
+## Files Changed
+- `addons_custom/product_weight_pricing/models/product_product.py`
+- `addons_custom/product_weight_pricing/static/src/js/pos_pricing_method.js`
+- `z-todolist/_todolis.md`
+
+## Apply / Verify
+- ✅ `python3 -m compileall addons_custom/product_weight_pricing`
+- ☐ POS manual check once frontend assets are rebuilt/reloaded.
+
+## Next
+- [ ] Reload POS (update module + hard refresh) to validate UI output once environment is available.
+- [ ] Capture screenshots in POS after verification if required.
+
+## Detailed Technical Analysis Process
+- Reviewed `pos_gold_pricing` and `product_weight_pricing` models to understand how POS pulls metal pricing and weight metadata.
+- Identified that `pos_compute_price_by_weight` always fell back to the legacy `default_metal_type`/`au_9999` when template defaults were missing, so attribute-based metal selections (e.g., "成色" → "足金") never influenced the lookup.
+- Implemented attribute-derived metal type resolution by parsing the variant's `product_template_attribute_value_ids`, prioritising tokens from "成色"/"金种" style attributes and matching them against `metal.type` records.
+- Updated the POS orderline patch to rely on the server-provided gram price for display, ensuring the label renders as "￥<price>/g x <weight> g" with proper spacing and currency formatting.
+- Ran `python3 -m compileall addons_custom/product_weight_pricing` to catch syntax issues in the modified Python module.
+
+## Work Summary
+- Added metal type detection from product attribute values so weight-based products fetch the correct daily price (`足金` → ¥512/g).
+- Refined POS orderline display logic to show the gram price multiplied by the configured weight with clearer formatting.
+


### PR DESCRIPTION
## Summary
- derive the metal type for POS weight pricing from variant attribute values when no default is set, so daily prices like 足金 are applied
- format the POS by-weight orderline label using the gram rate returned by the backend together with the configured weight
- record the new task and progress in the shared to-do tracker

## Testing
- python3 -m compileall addons_custom/product_weight_pricing


------
https://chatgpt.com/codex/tasks/task_e_68e754ef461c83209fbb705a0af5ebfc