### PR TITLE
Explain purchase UoM location in product workflow guide

### DIFF
--- a/doc/product_full_workflow_cn.md
+++ b/doc/product_full_workflow_cn.md
@@ -58,7 +58,7 @@
 2. **计件产品（按数量采购）（Unit-Based Products）**
    1. 在`常规信息`页签：（On the General Information tab:）
       - `计量单位` 选择“件/个”等数量单位。（Set Unit of Measure to pieces, such as Units.）
-      - `采购计量单位` 保持一致（通常同样为“件”）。（Keep the Purchase UoM consistent, typically Units.）
+      - `采购计量单位` 保持一致（通常同样为“件”）。该字段位于“常规信息”页签右侧的“计量单位”区块，在`计量单位`字段正下方；若页面未显示，请先在库存设置中启用“多计量单位”后刷新表单。（Keep the Purchase UoM consistent, typically Units. The field sits on the General Information tab in the Units of Measure block on the right, directly below Unit of Measure; enable Multi-Units of Measure in Inventory settings and reload if it does not appear.）
       - `销售价格` 或 `成本` 填写每件价格。（Enter the per-unit sales price or cost.）
    2. 切换至`采购`页签：（Switch to the Purchase tab:）
       - 在`供应商列表`中添加供应商，`价格`填写“每件采购价”，`最小数量`填写1。（Add vendors with unit purchase prices and a minimum quantity of 1.）

--- a/z-todolist/_todolis.md
+++ b/z-todolist/_todolis.md
@@ -249,3 +249,14 @@ Checklist
 - [x] 为每个操作步骤补充对应英文描述
 - [x] 自查文档排版与标点，确保中英并列清晰
 - [x] 总结变更并更新待办记录
+
+## task202510101530-describe-purchase-uom
+
+Original Request
+> 文档./doc/product_full_workflow_cn.md中下面的描述，详细说明一下如何找到`采购计量单位`这个操作位置。
+
+Checklist
+- [x] Review the existing instructions around purchase UoM in the product workflow doc
+- [x] Update `doc/product_full_workflow_cn.md` to explain how to find the Purchase UoM field
+- [x] Record execution details in the dedicated task log
+- [x] Verify formatting and instructions in the updated documentation

--- a/z-todolist/task202510101530-describe-purchase-uom.md
+++ b/z-todolist/task202510101530-describe-purchase-uom.md
@@ -1,0 +1,37 @@
+# task202510101530-describe-purchase-uom
+
+## Original Request
+文档./doc/product_full_workflow_cn.md中下面的描述，详细说明一下如何找到`采购计量单位`这个操作位置。
+
+## Improved English Phrasing
+In the document `doc/product_full_workflow_cn.md`, expand the description to explain in detail how to locate the "Purchase Unit of Measure" field.
+
+## Technical Analysis
+- Need to edit the Chinese product workflow documentation section that describes unit-based products.
+- Provide actionable navigation guidance in Odoo UI for locating the "Purchase Unit of Measure" (采购计量单位) setting on the product form.
+- Ensure the explanation fits the context of the existing bullet list and maintains consistent formatting and tone.
+
+## Steps
+1. Review the relevant section of `doc/product_full_workflow_cn.md` to understand current wording and structure. ✅
+2. Draft additional sentences or sub-bullets describing the navigation path to the Purchase UoM field. ✅
+3. Update the document while keeping style and bilingual formatting consistent. ✅
+4. Proofread formatting and ensure Markdown renders correctly. ✅
+
+## Files Changed
+- `doc/product_full_workflow_cn.md`
+- `z-todolist/_todolis.md`
+- `z-todolist/task202510101530-describe-purchase-uom.md`
+
+## Apply / Verify
+- Preview Markdown formatting locally (visual inspection). ✅
+
+## Next
+- None after documentation is updated and verified.
+
+## Detailed Technical Analysis Process
+- Located the "Unit-Based Products" subsection within the master data configuration chapter of `doc/product_full_workflow_cn.md`.
+- Confirmed that the Purchase UoM field lives in the same block as the standard UoM field on the product form and that visibility depends on enabling Multi-Units of Measure.
+- Added bilingual guidance explaining the exact position of the field and the prerequisite configuration so readers can navigate to it confidently.
+
+## Work Summary / 变更说明
+- 已在文档中补充“采购计量单位”字段所在位置及前置设置的说明，并完成格式校对。


### PR DESCRIPTION
## Summary
- clarify where to locate the Purchase Unit of Measure field within the product form documentation
- mention enabling Multi-Units of Measure if the field is hidden and refresh is needed
- capture the task entry and checklist updates in the z-todolist records

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68e8c3b1240c8320b04f3294cea74e09